### PR TITLE
Send slippage parameter value

### DIFF
--- a/Solnet.JupiterSwap/JupiterDex.cs
+++ b/Solnet.JupiterSwap/JupiterDex.cs
@@ -83,8 +83,13 @@ namespace Solnet.JupiterSwap
             new("outputMint", outputMint.ToString()),
             new("amount", amount.ToString()),
             new("swapMode", swapMode.ToString()),
-            new("asLegacyTransaction", "true")
+            new("asLegacyTransaction", "true"),
         };
+
+            if (slippageBps.HasValue)
+            { 
+              queryParams.Add(new("slippageBps", slippageBps.Value.ToString()));
+            }
 
             var queryString = string.Join("&", queryParams.Select(kv => $"{kv.Key}={kv.Value}"));
 


### PR DESCRIPTION
Up until now, `slippageBps` was only declared as a parameter, but it wasn't used